### PR TITLE
マップ移動時にクラッシュするバグを修正

### DIFF
--- a/Classes/Effects/AmbientLightLayer.h
+++ b/Classes/Effects/AmbientLightLayer.h
@@ -41,12 +41,14 @@ public:
     void setAmbient(const Color3B& color);
     void addLightSource(Light* lightSource);
     void removeLightSource(Light* lightSource);
-    void update(float delta);
-    virtual void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags);
+    void update(float delta) override;
+    virtual void visit(Renderer* renderer, const Mat4& parentTransform, uint32_t parentFlags) override;
 private:
     AmbientLightLayer();   // コンストラクタ
     ~AmbientLightLayer();  // デストラクタ
     bool init(const Color3B& color);    // 初期化
+    void onEnter() override;
+    void onExit() override;
 };
 
 #endif /* defined(_AmbientLightLayer__) */


### PR DESCRIPTION
- RenderTextureの解放タイミングを遅くした

- RenderTextureの対象になるSpriteの解放タイミングを遅くした

以上で解決