### PR TITLE
giveItemイベントで渡し元を指定できるように変更

### DIFF
--- a/Classes/Event/EventScriptMember.h
+++ b/Classes/Event/EventScriptMember.h
@@ -30,6 +30,7 @@ namespace member
     static const char* FALSE_ = "false";
     static const char* FAVORITE = "favorite";
     static const char* FLAG = "flg";
+    static const char* FROM_CHARA_ID = "fromCharaID";
     static const char* FILE = "file";
     static const char* CLASS_NAME = "className";
     static const char* ID = "id";
@@ -59,6 +60,7 @@ namespace member
     static const char* TIME = "time";
     static const char* TITLE = "title";
     static const char* TIMES = "times";
+    static const char* TO_CHARA_ID = "toCharaID";
     static const char* TROPHY_ID = "trophyID";
     static const char* TRUE_ = "true";
     static const char* TRIGGER = "trigger";

--- a/Classes/Event/FlagEvent.cpp
+++ b/Classes/Event/FlagEvent.cpp
@@ -244,9 +244,16 @@ bool GiveItemEvent::init(rapidjson::Value& json)
 {
     if(!GameEvent::init()) return false;
     
-    // charaId
-    if (!this->validator->hasMember(json, member::CHARA_ID)) return false;
-    this->charaId = stoi(json[member::CHARA_ID].GetString());
+    // toCharaId
+    if (!this->validator->hasMember(json, member::TO_CHARA_ID)) return false;
+    this->toCharaId = stoi(json[member::TO_CHARA_ID].GetString());
+    if (this->toCharaId == etoi(CharacterID::UNDIFINED)) return false;
+    
+    // fromCharaId
+    if (this->validator->hasMember(json, member::FROM_CHARA_ID))
+    {
+        this->fromCharaId = stoi(json[member::FROM_CHARA_ID].GetString());
+    }
     
     return true;
 }
@@ -254,11 +261,16 @@ bool GiveItemEvent::init(rapidjson::Value& json)
 void GiveItemEvent::run()
 {
     LocalPlayerData* localPlayerData { PlayerDataManager::getInstance()->getLocalData() };
-    vector<int> items { localPlayerData->getItemAll() };
+    if (this->fromCharaId == etoi(CharacterID::UNDIFINED))
+    {
+        this->fromCharaId = localPlayerData->getMainCharaId();
+    }
+    
+    vector<int> items { localPlayerData->getItemAll(this->fromCharaId) };
     for (auto item: items)
     {
-        localPlayerData->setItem(this->charaId, item);
-        localPlayerData->removeItem(item);
+        localPlayerData->setItem(this->toCharaId, item);
+        localPlayerData->removeItem(this->fromCharaId, item);
     }
     this->setDone();
 }

--- a/Classes/Event/FlagEvent.h
+++ b/Classes/Event/FlagEvent.h
@@ -133,7 +133,8 @@ class GiveItemEvent : public GameEvent
 public:
     CREATE_FUNC_WITH_PARAM(GiveItemEvent, rapidjson::Value&)
 private:
-    int charaId {-1};
+    int fromCharaId {-1};
+    int toCharaId {-1};
 private:
     GiveItemEvent() {FUNCLOG};
     ~GiveItemEvent() {FUNCLOG};

--- a/Classes/Models/LocalPlayerData.cpp
+++ b/Classes/Models/LocalPlayerData.cpp
@@ -251,9 +251,14 @@ void LocalPlayerData::setItem(const int charaId, const int itemId)
 // アイテムを消費
 bool LocalPlayerData::removeItem(const int itemId)
 {
+    return this->removeItem(this->getMainCharaId());
+}
+
+bool LocalPlayerData::removeItem(const int charaId, const int itemId)
+{
     bool isExist = false;
     char cidChar[10];
-    LastSupper::StringUtils::setCharsFromInt(cidChar, this->getMainCharaId());
+    LastSupper::StringUtils::setCharsFromInt(cidChar, charaId);
     this->setItemsObject(cidChar);
     vector<int> items {this->getItemAll()};
     this->localData[ITEMS][cidChar][ITEM].Clear();
@@ -291,9 +296,14 @@ bool LocalPlayerData::removeItem(const int itemId)
 // 所持しているアイテムをすべて取得
 vector<int> LocalPlayerData::getItemAll()
 {
+    return this->getItemAll(this->getMainCharaId());
+}
+
+vector<int> LocalPlayerData::getItemAll(const int charaId)
+{
     vector<int> items {};
     char cidChar[10];
-    LastSupper::StringUtils::setCharsFromInt(cidChar, this->getMainCharaId());
+    LastSupper::StringUtils::setCharsFromInt(cidChar, charaId);
     this->setItemsObject(cidChar);
     rapidjson::Value& itemList = this->localData[ITEMS][cidChar][ITEM];
     int itemCount = itemList.Size();
@@ -306,6 +316,11 @@ vector<int> LocalPlayerData::getItemAll()
 
 // アイテムを所持しているか確認
 bool LocalPlayerData::hasItem(const int itemId)
+{
+    return this->hasItem(this->getMainCharaId(), itemId);
+}
+
+bool LocalPlayerData::hasItem(const int charaId, const int itemId)
 {
     char cidChar[10];
     LastSupper::StringUtils::setCharsFromInt(cidChar, this->getMainCharaId());

--- a/Classes/Models/LocalPlayerData.h
+++ b/Classes/Models/LocalPlayerData.h
@@ -99,8 +99,11 @@ public:
     void setItem(const int itemId);
     void setItem(const int charaId, const int itemId);
     bool removeItem(const int itemId);
+    bool removeItem(const int charaId, const int itemId);
     vector<int> getItemAll();
+    vector<int> getItemAll(const int charaId);
     bool hasItem(const int itemId);
+    bool hasItem(const int charaId, const int itemId);
     
     // Character prifile
     void setCharacterProfile(const int chara_id, const int level);

--- a/Classes/Models/LocalPlayerData.h
+++ b/Classes/Models/LocalPlayerData.h
@@ -88,9 +88,7 @@ public:
     int getMaxFriendshipCount();
     
     // Items
-    char* getCharaIdChar(char* charaId);
-    char* getCharaIdChar(char* charaId, const int intCharaID);
-    void checkItemsObject(char* charaId);
+    void setItemsObject(char* charaId);
     
     // Equipment
     void setItemEquipment(const Direction direction, const int itemId);
@@ -123,6 +121,7 @@ public:
     Location getLocation(const int num = 0);
     CharacterData getPartyMember(const int num = 0);
     vector<CharacterData> getPartyMemberAll();
+    int getMainCharaId();
     
     // BGM
     void setBgm(const string& bgm_name);

--- a/Classes/Utils/StringUtils.cpp
+++ b/Classes/Utils/StringUtils.cpp
@@ -90,3 +90,9 @@ void LastSupper::StringUtils::encryptXor(string& str)
         str[i] ^= C_KEY;
     }
 }
+
+char* LastSupper::StringUtils::setCharsFromInt(char *charas, const int num)
+{
+    sprintf(charas, "%d", num);
+    return charas;
+}

--- a/Classes/Utils/StringUtils.h
+++ b/Classes/Utils/StringUtils.h
@@ -21,6 +21,7 @@ namespace LastSupper
         string getRandomString(const int length = 50);
         string getTimeForDisplay(const int sec);
         void encryptXor(string& str);
+        char* setCharsFromInt(char* charas, const int num);
     }
 }
 


### PR DESCRIPTION
ex) ダイゴローからシュカへアイテム渡し
```json
{
    "type": "giveItem",
    "fromCharaID": "5",
    "toCharaID": "7"
}
```

現在の主人公から渡す場合は、`fromCharaID`を省略してもいい
ex) 現在の主人公からシュカへアイテム渡し
```json
{
    "type": "giveItem",
    "toCharaID": "7"
}
```