### PR TITLE
removeItemで落ちるの解消

### DIFF
--- a/Classes/Event/FlagEvent.cpp
+++ b/Classes/Event/FlagEvent.cpp
@@ -100,7 +100,11 @@ bool RemoveItemEvent::init(rapidjson::Value& json)
 void RemoveItemEvent::run()
 {
     this->setDone();
-    PlayerDataManager::getInstance()->getLocalData()->removeItem(this->itemId);
+    bool isExist = PlayerDataManager::getInstance()->getLocalData()->removeItem(this->itemId);
+    // アイテムが存在しない場合
+    if (!isExist) {
+        LastSupper::AssertUtils::warningAssert("Warning: removeItemEvent\nitemID: "+ to_string(itemId) +"\nこのアイテムは持っていません");
+    }
 }
 
 #pragma mark -

--- a/Classes/Models/LocalPlayerData.cpp
+++ b/Classes/Models/LocalPlayerData.cpp
@@ -8,6 +8,7 @@
 
 #include "Models/LocalPlayerData.h"
 #include "Models/GlobalPlayerData.h"
+#include "Utils/AssertUtils.h"
 #include "Utils/JsonUtils.h"
 #include "Utils/StringUtils.h"
 #include "Datas/MapObject/CharacterData.h"

--- a/Classes/Models/LocalPlayerData.cpp
+++ b/Classes/Models/LocalPlayerData.cpp
@@ -251,7 +251,7 @@ void LocalPlayerData::setItem(const int charaId, const int itemId)
 // アイテムを消費
 bool LocalPlayerData::removeItem(const int itemId)
 {
-    return this->removeItem(this->getMainCharaId());
+    return this->removeItem(this->getMainCharaId(), itemId);
 }
 
 bool LocalPlayerData::removeItem(const int charaId, const int itemId)

--- a/Classes/Scenes/AssertScene.cpp
+++ b/Classes/Scenes/AssertScene.cpp
@@ -32,8 +32,18 @@ bool AssertScene::init(const string& message, const AssertType& assertType)
             color = Color4B::BLUE;
             hideable = true;
             break;
+        case AssertType::WARNING:
+            title = "WarningAssert";
+            color = Color4B::ORANGE;
+            hideable = true;
+            break;
         case AssertType::FATAL:
-            title = DebugManager::getInstance()->isPlainData() ? "FatalAssert" : "SystemError";
+            title = "FatalAssert";
+            color = Color4B::BLACK;
+            hideable = false;
+            break;
+        case AssertType::ERROR:
+            title = "SystemError";
             color = Color4B::BLACK;
             hideable = false;
             break;

--- a/Classes/Scenes/AssertScene.h
+++ b/Classes/Scenes/AssertScene.h
@@ -19,8 +19,10 @@ class AssertScene : public BaseScene
 public:
     enum struct AssertType
     {
-        INFO,
-        FATAL
+        INFO, // デバッグ用お知らせ
+        WARNING, // 修正必要な警告
+        FATAL, // 致命的なエラー
+        ERROR // ユーザー出力用
     };
 
     // クラスメソッド

--- a/Classes/Utils/AssertUtils.cpp
+++ b/Classes/Utils/AssertUtils.cpp
@@ -15,20 +15,33 @@ void LastSupper::AssertUtils::infoAssert(const string& message)
     // デバッグじゃない時は出さない
     if(!DebugManager::getInstance()->isPlainData()) return;
     
-    BaseScene* nowScene = (BaseScene*)Director::getInstance()->getRunningScene();
     AssertScene* assert { AssertScene::create(message, AssertScene::AssertType::INFO) };
+    
+    BaseScene* nowScene = (BaseScene*)Director::getInstance()->getRunningScene();
     assert->onEnterAssertScene = CC_CALLBACK_0(BaseScene::onEnterAssertScene, nowScene);
     assert->onExitAssertScene = CC_CALLBACK_0(BaseScene::onExitAssertScene, nowScene);
-    // assertをプッシュ
     Director::getInstance()->pushScene(assert);
 }
 
-void LastSupper::AssertUtils::fatalAssert(const string& message)
+void LastSupper::AssertUtils::warningAssert(const string& message)
 {
+    // デバッグじゃない時は出さない
+    if(!DebugManager::getInstance()->isPlainData()) return;
+    
+    AssertScene* assert { AssertScene::create(message, AssertScene::AssertType::WARNING) };
+    
     BaseScene* nowScene = (BaseScene*)Director::getInstance()->getRunningScene();
-    AssertScene* assert { AssertScene::create(message, AssertScene::AssertType::FATAL) };
     assert->onEnterAssertScene = CC_CALLBACK_0(BaseScene::onEnterAssertScene, nowScene);
     assert->onExitAssertScene = CC_CALLBACK_0(BaseScene::onExitAssertScene, nowScene);
-    // assertをプッシュ
+    Director::getInstance()->pushScene(assert);}
+
+void LastSupper::AssertUtils::fatalAssert(const string& message)
+{
+    AssertScene::AssertType assertType = DebugManager::getInstance()->isPlainData() ? AssertScene::AssertType::FATAL : AssertScene::AssertType::ERROR;
+    AssertScene* assert { AssertScene::create(message, assertType) };
+    
+    BaseScene* nowScene = (BaseScene*)Director::getInstance()->getRunningScene();
+    assert->onEnterAssertScene = CC_CALLBACK_0(BaseScene::onEnterAssertScene, nowScene);
+    assert->onExitAssertScene = CC_CALLBACK_0(BaseScene::onExitAssertScene, nowScene);
     Director::getInstance()->pushScene(assert);
 }

--- a/Classes/Utils/AssertUtils.h
+++ b/Classes/Utils/AssertUtils.h
@@ -10,14 +10,17 @@
 #define AssertUtils_h
 
 #include "define.h"
+
+class AssertScene;
+
 namespace LastSupper
 {
     namespace AssertUtils
     {
         void infoAssert(const string& message);
+        void warningAssert(const string& message);
         void fatalAssert(const string& message);
     }
 }
-
 
 #endif /* AssertUtils_h */


### PR DESCRIPTION
 - removeItemで無限ループ引き起こすの解消
 - WarningAssert追加
 - デバッグ用FATALとユーザー用のERRORを切り分け