### PR TITLE
alreadyが一部効かないバグを修正

### DIFF
--- a/Classes/Event/SceneEvent.cpp
+++ b/Classes/Event/SceneEvent.cpp
@@ -150,6 +150,7 @@ bool EndingEvent::init(rapidjson::Value& json)
     if (!_eventHelper->hasMember(_json, member::CALLBACK_)) return false;
     
     _event = _factory->createGameEvent(json[member::CALLBACK_], this);
+    // @TODO: メモリリークしてそうなのでRELEASEすべきタイミングでリリースする。デストラクタだとまずそうなのでコールバック実行後とか？
     CC_SAFE_RETAIN(_event);
     return true;
 }


### PR DESCRIPTION
#141 
typeなしで自動的にspawnでイベント生成する場合にcallerをセットで来ていなかったことが原因
セットするようにしたが、そもそもルートのGameEventでmapIdとEventIdを初期化時に持っていないことが問題かも、callerいるときはなんも問題ないけど