### PR TITLE
イベント終了後にすぐエネミーが動き出さないバグを修正

### DIFF
--- a/Classes/MapObjects/Enemy.cpp
+++ b/Classes/MapObjects/Enemy.cpp
@@ -127,3 +127,10 @@ void Enemy::onBattleFinished()
     Character::onBattleFinished();
     _objectList->getAttackDetector()->addAttackBox(_attackBox);
 }
+
+// イベント終了時
+void Enemy::onEventFinished()
+{
+    Character::onEventFinished();
+    _movePattern->start();
+}

--- a/Classes/MapObjects/Enemy.h
+++ b/Classes/MapObjects/Enemy.h
@@ -44,6 +44,7 @@ public:
     virtual void onExitMap() override;
     virtual void onBattleStart() override;
     virtual void onBattleFinished() override;
+    virtual void onEventFinished() override;
 };
 
 #endif /* defined(__LastSupper__Enemy__) */


### PR DESCRIPTION
#129 
イベント終了後にすぐエネミーが動き出さないバグを修正