### PR TITLE
EventSequenceがdoneなのにupdateが呼ばれて次のjsonを参照して落ちるバグを修正

### DIFF
--- a/Classes/Event/GameEvent.cpp
+++ b/Classes/Event/GameEvent.cpp
@@ -207,6 +207,8 @@ void EventSpawn::update(float delta)
     bool allDone { true };
     
     for (GameEvent* event : _events) {
+        if(event->isDone()) continue;
+        
         event->update(delta);
         
         if (!event->isDone()) allDone = false;


### PR DESCRIPTION
もしくは
```
// インデックス = 要素の個数なら終了
    if (_currentIdx >= _json.Size()) {
        this->setDone();
        return;
    }
```
とすれば解決?

とりあえず、setDoneした後にEventSequenceのupdateが呼ばれて_currentIdx++;して_json.Size()を超えちゃうのがまずいです