### PR TITLE
戦闘用キャラクターデータにステップと攻撃のスタミナ及び硬直時間を追加

### DIFF
--- a/Classes/Datas/AttackData.cpp
+++ b/Classes/Datas/AttackData.cpp
@@ -1,0 +1,9 @@
+//
+//  AttackData.cpp
+//  6chefs2
+//
+//  Created by Ryoya Ino on 2016/12/20.
+//
+//
+
+#include "AttackData.h"

--- a/Classes/Datas/AttackData.h
+++ b/Classes/Datas/AttackData.h
@@ -1,0 +1,37 @@
+//
+//  AttackData.hpp
+//  6chefs2
+//
+//  Created by Ryoya Ino on 2016/12/20.
+//
+//
+
+#ifndef AttackData_h
+#define AttackData_h
+
+#include "define.h"
+
+struct AttackData : public Ref
+{
+private:
+    string name;
+
+public:
+    int power { 50 };
+    float stamina { 5.0f };
+    float intervalTime { 0.5f };
+
+private:
+    AttackData(){};
+    ~AttackData(){};
+    
+public:
+    CREATE_FUNC_WITH_PARAM(AttackData, const string&);
+    bool init(const string& attackName)
+    {
+        name = attackName;
+        return true;
+    }
+};
+
+#endif /* AttackData_hpp */

--- a/Classes/Datas/BattleCharacterData.cpp
+++ b/Classes/Datas/BattleCharacterData.cpp
@@ -8,6 +8,7 @@
 
 #include "Datas/BattleCharacterData.h"
 
+#include "Datas/AttackData.h"
 #include "Helpers/AssertHelper.h"
 #include "Utils/StringUtils.h"
 #include "Utils/JsonUtils.h"
@@ -15,8 +16,21 @@
 const char* BattleCharacterData::HIT_POINT {"hit_point"};
 const char* BattleCharacterData::SPEED_RATIO {"speed_ratio"};
 const char* BattleCharacterData::ATTACKS {"attacks"};
+const char* BattleCharacterData::STEP_INTERVAL_TIME {"step_interval_time"};
+const char* BattleCharacterData::STEP_STAMINA {"step_stamina"};
+const char* BattleCharacterData::POWER {"power"};
+const char* BattleCharacterData::STAMINA {"stamina"};
+const char* BattleCharacterData::INTERVAL_TIME {"interval_time"};
+
 
 rapidjson::Document BattleCharacterData::BATTLE_CHARACTER_DATA { rapidjson::Document() };
+
+BattleCharacterData::~BattleCharacterData()
+{
+    for (auto attack : _attacks) {
+        CC_SAFE_RELEASE_NULL(attack.second);
+    }
+}
 
 bool BattleCharacterData::init(const string &charaId)
 {
@@ -42,6 +56,8 @@ bool BattleCharacterData::init(const string &charaId)
     if (!this->setHitPoint(battleCharacterData)) return false;
     if (!this->setSpeedRatio(battleCharacterData)) return false;
     if (!this->setAttacks(battleCharacterData)) return false;
+    if (!this->setStepStamina(battleCharacterData)) return false;
+    if (!this->setStepIntervalTime(battleCharacterData)) return false;
     
     _charaId = charaId;
     
@@ -108,13 +124,79 @@ bool BattleCharacterData::setAttacks(const rapidjson::Value &battleCharacterData
     for (rapidjson::Value::ConstMemberIterator itr = attacks.MemberBegin();itr != attacks.MemberEnd(); itr++)
     {
         string attackName = itr->name.GetString();
-        if (!itr->value.IsInt()) {
-            _assertHelper->pushTextLineKeyValue("attack_name", attackName)
-                            ->fatalAssert("Type of atack_point should be int.");
+        AttackData*
+        attackData { AttackData::create(attackName) };
+        _assertHelper->pushTextLineKeyValue("attack_name", attackName);
+        
+        // power
+        if (!itr->value.HasMember(BattleCharacterData::POWER)) {
+            _assertHelper->fatalAssert("power is missing.");
             return false;
         }
-        _attacks[attackName] = itr->value.GetInt();
+        if (!itr->value[BattleCharacterData::POWER].IsInt()) {
+            _assertHelper->fatalAssert("Type of power should be int");
+            return false;
+        }
+        attackData->power = itr->value[BattleCharacterData::POWER].GetInt();
+        
+        // stamina
+        if (!itr->value.HasMember(BattleCharacterData::STAMINA)) {
+            _assertHelper->fatalAssert("stamina is missing.");
+            return false;
+        }
+        if (!itr->value[BattleCharacterData::STAMINA].IsDouble()) {
+            _assertHelper->fatalAssert("Type of stamina should be double");
+            return false;
+        }
+        attackData->stamina = itr->value[BattleCharacterData::STAMINA].GetDouble();
+        
+        // interval time
+        if (!itr->value.HasMember(BattleCharacterData::INTERVAL_TIME)) {
+            _assertHelper->fatalAssert("interval_time is missing.");
+            return false;
+        }
+        if (!itr->value[BattleCharacterData::INTERVAL_TIME].IsDouble()) {
+            _assertHelper->fatalAssert("Type of interval_time should be double");
+            return false;
+        }
+        attackData->intervalTime = itr->value[BattleCharacterData::INTERVAL_TIME].GetDouble();
+        
+        CC_SAFE_RETAIN(attackData);
+        _attacks[attackName] = attackData;
+        _assertHelper->popTextLine();
     }
+    return true;
+}
+
+bool BattleCharacterData::setStepStamina(const rapidjson::Value &battleCharacterData)
+{
+    if (!battleCharacterData.HasMember(BattleCharacterData::STEP_STAMINA)) {
+        _assertHelper->fatalAssert("step_stamina is missing.");
+        return false;
+    }
+    
+    if (!battleCharacterData[STEP_STAMINA].IsDouble()) {
+        _assertHelper->fatalAssert("Type of step_stamina should be double.");
+        return false;
+    }
+    
+    _stepStamina = battleCharacterData[STEP_STAMINA].GetDouble();
+    return true;
+}
+
+bool BattleCharacterData::setStepIntervalTime(const rapidjson::Value &battleCharacterData)
+{
+    if (!battleCharacterData.HasMember(BattleCharacterData::STEP_INTERVAL_TIME)) {
+        _assertHelper->fatalAssert("step_interval_time is missing.");
+        return false;
+    }
+    
+    if (!battleCharacterData[STEP_INTERVAL_TIME].IsDouble()) {
+        _assertHelper->fatalAssert("Type of step_interval_time should be double.");
+        return false;
+    }
+    
+    _stepIntervalTime = battleCharacterData[STEP_INTERVAL_TIME].GetDouble();
     return true;
 }
 
@@ -131,13 +213,22 @@ float BattleCharacterData::getSpeedRatio() const
     return _speedRatio;
 }
 
-int BattleCharacterData::getAttackPoint(const string &attackName) const
+float BattleCharacterData::getStepStamina() const
+{
+    return _stepStamina;
+}
+
+float BattleCharacterData::getStepIntervalTime() const
+{
+    return _stepIntervalTime;
+}
+
+AttackData* BattleCharacterData::getAttackData(const string &attackName) const
 {
     if (_attacks.count(attackName) == 0) {
         _assertHelper->pushTextLineKeyValue("attack_name", attackName)
-                            ->fatalAssert("attack_point is missing.");
-        return 0;
+        ->fatalAssert("attack data is missing.");
+        return nullptr;
     }
-    
     return _attacks.at(attackName);
 }

--- a/Classes/Datas/BattleCharacterData.h
+++ b/Classes/Datas/BattleCharacterData.h
@@ -12,6 +12,7 @@
 #include "define.h"
 
 class AssertHelper;
+class AttackData;
 
 class BattleCharacterData: public Ref
 {
@@ -19,6 +20,11 @@ public:
     static const char* HIT_POINT;
     static const char* SPEED_RATIO;
     static const char* ATTACKS;
+    static const char* STEP_INTERVAL_TIME;
+    static const char* STEP_STAMINA;
+    static const char* POWER;
+    static const char* STAMINA;
+    static const char* INTERVAL_TIME;
     
 private:
     static rapidjson::Document BATTLE_CHARACTER_DATA;
@@ -26,25 +32,31 @@ private:
 private:
     AssertHelper* _assertHelper {nullptr};
     string _charaId {};
-    map<string, int> _attacks {};
+    map<string, AttackData*> _attacks {};
     int _hitPoint {100};
     float _speedRatio {1.0f};
+    float _stepStamina {5.0f};
+    float _stepIntervalTime {0.5f};
     
 private:
     BattleCharacterData() {FUNCLOG};
-    ~BattleCharacterData() {FUNCLOG};
+    ~BattleCharacterData();
     bool init(const string& charaId);
     bool init(const int charaId);
     bool setHitPoint(const rapidjson::Value& battleCharacterData);
     bool setSpeedRatio(const rapidjson::Value& battleCharacterData);
     bool setAttacks(const rapidjson::Value& battleCharacterData);
+    bool setStepStamina(const rapidjson::Value& battleCharacterData);
+    bool setStepIntervalTime(const rapidjson::Value& battleCharacterData);
 
 public:
     CREATE_FUNC_WITH_PARAM(BattleCharacterData, const string&);
     CREATE_FUNC_WITH_PARAM(BattleCharacterData, const int);
     int getHitPoint() const;
     float getSpeedRatio() const;
-    int getAttackPoint(const string& attackName) const;
+    AttackData* getAttackData(const string& attackName) const;
+    float getStepIntervalTime() const;
+    float getStepStamina() const;
 };
 
 #endif /* BattleCharacterData_h */

--- a/Classes/MapObjects/Command/AttackCommand.cpp
+++ b/Classes/MapObjects/Command/AttackCommand.cpp
@@ -9,6 +9,7 @@
 #include "MapObjects/Command/AttackCommand.h"
 
 #include "Datas/BattleCharacterData.h"
+#include "Datas/AttackData.h"
 #include "MapObjects/Character.h"
 #include "MapObjects/DetectionBox/AttackBox.h"
 #include "MapObjects/Status/Stamina.h"
@@ -66,7 +67,7 @@ void AttackCommand::execute(MapObject* target)
     }
     
     character->beInAttackMotion(true);
-    character->getBattleAttackBox()->setPower(character->getBattleCharacterData()->getAttackPoint(_name));
+    character->getBattleAttackBox()->setPower(character->getBattleCharacterData()->getAttackData(_name)->power);
     character->playAnimation(Character::AnimationName::getAttack(_name, character->getDirection()), CC_CALLBACK_1(AttackCommand::onAttackAnimationFinished, this));
     
     if (_stamina) {

--- a/Resources/config/BattleCharacter.json
+++ b/Resources/config/BattleCharacter.json
@@ -2,50 +2,90 @@
     "2": {
         "name": "ranmaru",
         "attacks": {
-            "attack": 30
+            "attack": {
+                "power": 30,
+                "stamina": 5.0,
+                "interval_time": 0.5
+            }
         },
         "hit_point": 100,
+        "step_stamina": 5.0,
+        "step_interval_time": 0.5,
         "speed_ratio": 1.0
     },
     "5": {
         "name": "daigoro",
         "attacks": {
-            "attack": 30
+            "attack": {
+                "power": 30,
+                "stamina": 5.0,
+                "interval_time": 0.5
+            }
         },
         "hit_point": 100,
+        "step_stamina": 5.0,
+        "step_interval_time": 0.5,
         "speed_ratio": 1.0
     },
     "6": {
         "name": "yuki",
         "attacks": {
-            "attack": 30
+            "attack": {
+                "power": 30,
+                "stamina": 5.0,
+                "interval_time": 0.5
+            }
         },
         "hit_point": 100,
+        "step_stamina": 5.0,
+        "step_interval_time": 0.5,
         "speed_ratio": 1.0
     },
     "8": {
         "name": "tamuken",
         "attacks": {
-            "attack": 30
+            "attack": {
+                "power": 30,
+                "stamina": 5.0,
+                "interval_time": 0.5
+            }
         },
         "hit_point": 100,
+        "step_stamina": 5.0,
+        "step_interval_time": 0.5,
         "speed_ratio": 1.0
     },
     "9": {
         "name": "taihou",
         "attacks": {
-            "attack_1": 75,
-            "attack_2": 75
+            "attack_1": {
+                "power": 75,
+                "stamina": 5.0,
+                "interval_time": 0.5
+            },
+            "attack_2": {
+                "power": 75,
+                "stamina": 5,
+                "interval_time": 0.5
+            }
         },
         "hit_point": 125,
+        "step_stamina": 5.0,
+        "step_interval_time": 0.5,
         "speed_ratio": 1.0
     },
     "13": {
         "name": "kyoujin",
-        "attacks": {
-            "attack": 50
+        "attacks":{
+            "attack": {
+                "power": 50,
+                "stamina": 5.0,
+                "interval_time": 0.5
+            }
         },
         "hit_point": 75,
+        "step_stamina": 5.0,
+        "step_interval_time": 0.5,
         "speed_ratio": 1.0
     }
 }

--- a/proj.ios_mac/6chefs2.xcodeproj/project.pbxproj
+++ b/proj.ios_mac/6chefs2.xcodeproj/project.pbxproj
@@ -461,6 +461,7 @@
 		2672D5031D72F79700AC0E96 /* MasterConfigData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MasterConfigData.h; path = ConfigData/MasterConfigData.h; sourceTree = "<group>"; };
 		2672D5061D734C7F00AC0E96 /* EventScriptValidator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventScriptValidator.cpp; sourceTree = "<group>"; };
 		2672D5071D734C7F00AC0E96 /* EventScriptValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventScriptValidator.h; sourceTree = "<group>"; };
+		268A35C91E0880DE00514032 /* AttackData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AttackData.h; sourceTree = "<group>"; };
 		268E3FA71D64BFD90098B235 /* ConfigDataManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConfigDataManager.cpp; sourceTree = "<group>"; };
 		268E3FA81D64BFD90098B235 /* ConfigDataManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConfigDataManager.h; sourceTree = "<group>"; };
 		269211551CE89FB5005C0E5A /* config */ = {isa = PBXFileReference; lastKnownFileType = folder; path = config; sourceTree = "<group>"; };
@@ -1146,6 +1147,7 @@
 				DC0390611C871E1000C50E8E /* Scene */,
 				2613244B1DE2081200E39526 /* BattleCharacterData.cpp */,
 				2613244C1DE2081200E39526 /* BattleCharacterData.h */,
+				268A35C91E0880DE00514032 /* AttackData.h */,
 			);
 			path = Datas;
 			sourceTree = "<group>";


### PR DESCRIPTION
#164 
ステップ系は普通に追加
攻撃系は攻撃ごとに設定できるようにした
```json
{
"2": {
        "name": "ranmaru",
        "attacks": {
            "attack": {
                "power": 30,
                "stamina": 5.0,
                "interval_time": 0.5
            }
        },
        "hit_point": 100,
        "step_stamina": 5.0,
        "step_interval_time": 0.5,
        "speed_ratio": 1.0
    }
}
```

攻撃ごとのデータの取得の使い方的にはこんな感じ
```cpp
BattleCharacterData* bcd { BattleCharacterData(charaId) };
int power { bcd->getAttackData("attackName")->power };
int power { bcd->getAttackData("attackName")->intervalTime };

or 

AttackData* ad { bcd->getAttackData("attackName") };
int power {ad->power};
float interval { ad->intervalTime };
```