### PR TITLE
水中状態に波のアニメーションと、waveInオプションの追加

### DIFF
--- a/Classes/Event/EffectEvent.h
+++ b/Classes/Event/EffectEvent.h
@@ -70,6 +70,8 @@ class CreateUnderwaterEvent : public GameEvent
 public:
     CREATE_FUNC_WITH_PARAM(CreateUnderwaterEvent, rapidjson::Value&)
 private:
+    bool _waveIn { false };
+private:
     CreateUnderwaterEvent() { FUNCLOG };
     ~CreateUnderwaterEvent() { FUNCLOG };
     virtual bool init(rapidjson::Value& json) override;

--- a/Classes/Event/EventScriptMember.h
+++ b/Classes/Event/EventScriptMember.h
@@ -74,6 +74,7 @@ namespace member
     static const char* Y = "y";
     static const char* VOICE = "voice";
     static const char* DISPLAY = "display";
+    static const char* WAVE_IN = "waveIn";
 }
 
 #endif /* defined(__LastSupper__EventScriptMember__) */

--- a/Resources/config/EventScriptValidator.json
+++ b/Resources/config/EventScriptValidator.json
@@ -453,6 +453,9 @@
         "createRain": {
         },
         "createUnderwater": {
+            "member": {
+                "waveIn": ["bool"]
+            }
         },
         
         


### PR DESCRIPTION
 - 通常状態で波のアニメーションを追加して、ちょっと水中気分を増やした
 - waveInオプションをtrueにすると波が画面を徐々に水で覆っていく形に

```json
{
    "type":"createUnderwarter",
    "waveIn":true 
}
```