### PR TITLE
メニューのキャラ表示とwaterの波打ち修正

### DIFF
--- a/Classes/Event/EffectEvent.cpp
+++ b/Classes/Event/EffectEvent.cpp
@@ -151,12 +151,14 @@ bool CreateUnderwaterEvent::init(rapidjson::Value& json)
 void CreateUnderwaterEvent::run()
 {
     this->setDone();
-    auto waterLayer = LayerColor::create(Color4B(88,255,255,128 ));
+    
+    auto waterLayer = LayerColor::create(Color4B(88,255,255,128));
+    
     ParticleSystemQuad* bubble = ParticleSystemQuad::create("img/bubble.plist");
     waterLayer->addChild(bubble);
-    waterLayer->setScale(0.99);
+    
     auto nodeGrid = NodeGrid::create();
-    nodeGrid->runAction(RepeatForever::create(Waves::create(10.f, Size(60, 60), 10, 5.0f, true, true)));
+    nodeGrid->runAction(RepeatForever::create(Waves::create(10.f, Size(60, 60), 10, 5.0f, true, false)));
     nodeGrid->addChild(waterLayer);
     
     if (this->_waveIn) {

--- a/Classes/Event/EffectEvent.cpp
+++ b/Classes/Event/EffectEvent.cpp
@@ -165,19 +165,15 @@ void CreateUnderwaterEvent::run()
         float layerHeight { waterLayer->getContentSize().height };
         waterLayer->setPosition(waterLayer->getPosition().x, - layerHeight);
         waterLayer->runAction(
-            Sequence::create(
+            Sequence::createWithTwoActions(
                 EaseSineInOut::create(MoveBy::create(1.0f, Vec2(0.f, 2 * layerHeight / 10))),
                 Repeat::create(
                     Sequence::createWithTwoActions(
                         EaseSineInOut::create(MoveBy::create(0.5f, Vec2(0.f, - layerHeight / 10))),
                         EaseSineInOut::create(MoveBy::create(1.0f, Vec2(0.f, 3 * layerHeight / 10)))
-                ), 4),
-                CallFunc::create([this](){this->setDone();}),
-                nullptr
+                ), 4)
             )
         );
-    } else {
-        this->setDone();
     }
     
     DungeonSceneManager::getInstance()->getScene()->addChild(nodeGrid);

--- a/Classes/Layers/Menu/DungeonMainMenuLayer.cpp
+++ b/Classes/Layers/Menu/DungeonMainMenuLayer.cpp
@@ -16,6 +16,7 @@
 
 // 定数
 const float DungeonMainMenuLayer::SLIDE_TIME {0.3f};
+const int DungeonMainMenuLayer::PARTY_DISPLAY_LIMIT {4};
 
 // コンストラクタ
 DungeonMainMenuLayer::DungeonMainMenuLayer(){FUNCLOG}
@@ -125,12 +126,14 @@ bool DungeonMainMenuLayer::init()
     
     // キャラ表示
     vector<CharacterData> charas = PlayerDataManager::getInstance()->getLocalData()->getPartyMemberAll();
-    int party_count = charas.size();
+    int partyCount = static_cast<int>(charas.size());
+    int partyDisplayLimit = DungeonMainMenuLayer::PARTY_DISPLAY_LIMIT < partyCount ?
+                                        DungeonMainMenuLayer::PARTY_DISPLAY_LIMIT : partyCount;
     Size  cPanelSize = Size(fBg->getContentSize().width/5, fBg->getContentSize().height);
     float stand_scale = 0.35;
-    for (int i = 0; i < party_count; i++)
+    for (int i = 0; i < partyDisplayLimit; i++)
     {
-        float colum_position = cPanelSize.width * (5 - party_count + i) + cPanelSize.width / 2;
+        float colum_position = cPanelSize.width * (5 - partyDisplayLimit + i) + cPanelSize.width / 2;
         // キャラ毎にパネルを作成
         Sprite* chara_panel {Sprite::create()};
         chara_panel->setTextureRect(Rect(0,0, cPanelSize.width, cPanelSize.height));

--- a/Classes/Layers/Menu/DungeonMainMenuLayer.h
+++ b/Classes/Layers/Menu/DungeonMainMenuLayer.h
@@ -31,6 +31,7 @@ public:
     // 定数
 public:
     static const float SLIDE_TIME;
+    static const int PARTY_DISPLAY_LIMIT;
 	
 	// クラスメソッド
 public:


### PR DESCRIPTION
 - メニューのキャラ表示4人まで #246 
 - waterはとりあえず横の波打ちは無くして、縦だけにした #245 