### PR TITLE
33分クッキング対応とTrophyConfig.jsonの新規実装

### DIFF
--- a/Classes/Managers/ConfigDataManager.cpp
+++ b/Classes/Managers/ConfigDataManager.cpp
@@ -35,6 +35,7 @@ ConfigDataManager::~ConfigDataManager()
     FUNCLOG
     CC_SAFE_RELEASE_NULL(this->debugConfigData);
     CC_SAFE_RELEASE_NULL(this->masterConfigData);
+    CC_SAFE_RELEASE_NULL(this->trophyConfigData);
 }
 
 // コンストラクタ
@@ -43,9 +44,11 @@ ConfigDataManager::ConfigDataManager()
     FUNCLOG
     this->debugConfigData = DebugConfigData::create();
     this->masterConfigData = MasterConfigData::create();
+    this->trophyConfigData = TrophyConfigData::create();
     
     CC_SAFE_RETAIN(this->debugConfigData);
     CC_SAFE_RETAIN(this->masterConfigData);
+    CC_SAFE_RETAIN(this->trophyConfigData);
 }
 
 // DebugConfigの取得
@@ -58,4 +61,10 @@ DebugConfigData* ConfigDataManager::getDebugConfigData()
 MasterConfigData* ConfigDataManager::getMasterConfigData()
 {
     return this->masterConfigData;
+}
+
+// TrophyConfigの取得
+TrophyConfigData* ConfigDataManager::getTrophyConfigData()
+{
+    return this->trophyConfigData;
 }

--- a/Classes/Managers/ConfigDataManager.h
+++ b/Classes/Managers/ConfigDataManager.h
@@ -13,6 +13,7 @@
 
 #include "Models/ConfigData/DebugConfigData.h"
 #include "Models/ConfigData/MasterConfigData.h"
+#include "Models/ConfigData/TrophyConfigData.h"
 
 class ConfigDataManager
 {
@@ -30,11 +31,13 @@ private:
 private:
     DebugConfigData* debugConfigData {};
     MasterConfigData* masterConfigData {};
+    TrophyConfigData* trophyConfigData {};
     
     // インスタンスメソッド
 public:
     DebugConfigData* getDebugConfigData();
     MasterConfigData* getMasterConfigData();
+    TrophyConfigData* getTrophyConfigData();
 };
 
 #endif /* ConfigDataManager_hpp */

--- a/Classes/Models/ConfigData/MasterConfigData.cpp
+++ b/Classes/Models/ConfigData/MasterConfigData.cpp
@@ -10,7 +10,6 @@
 
 #include "Utils/JsonUtils.h"
 #include "Utils/AssertUtils.h"
-#include "Utils/StringUtils.h"
 
 // 定数
 const char* MasterConfigData::VERSION {"version"};

--- a/Classes/Models/ConfigData/TrophyConfigData.cpp
+++ b/Classes/Models/ConfigData/TrophyConfigData.cpp
@@ -1,0 +1,55 @@
+//
+//  TrophyConfigData.cpp
+//  6chefs2
+//
+//  Created by Ryoya Ino on 2017/02/12.
+//
+//
+
+#include "Models/ConfigData/TrophyConfigData.h"
+
+#include "Utils/JsonUtils.h"
+#include "Utils/AssertUtils.h"
+
+// 定数
+const char* TrophyConfigData::FAST_CLEAR {"fast_clear"};
+const char* TrophyConfigData::NO_SAVE_CLEAR {"no_save_clear"};
+const char* TrophyConfigData::CHIKEN_SAVE {"chiken_save"};
+const char* TrophyConfigData::TROPHY_COMPLETE {"trophy_complete"};
+const char* TrophyConfigData::TROPHY_ID {"trophyID"};
+
+// コンストラクタ
+bool TrophyConfigData::init()
+{
+    FUNCLOG
+    this->filePath = FileUtils::getInstance()->fullPathForFilename(Resource::ConfigFiles::TROPHY_CONFIG);
+    if (this->filePath == "")
+    {
+        LastSupper::AssertUtils::fatalAssert(Resource::ConfigFiles::TROPHY_CONFIG + "is missing.");
+        return false;
+    }
+    this->trophyConfig = LastSupper::JsonUtils::readJsonCrypted(this->filePath);
+    return true;
+}
+
+// 設定されているtrophy_idの取得
+int TrophyConfigData::getTrophyId(const char *targetTrophy)
+{
+    return this->getTrophyData(targetTrophy)[TROPHY_ID].GetInt();
+}
+
+// 設定されているトロフィーのプロパティを取得
+int TrophyConfigData::getTrophyIntegerProperty(const char *targetTrophy, const char *targetProperty)
+{
+    return this->getTrophyData(targetTrophy)[targetProperty].GetInt();
+}
+
+// トロフィー設定データの取得
+rapidjson::Value& TrophyConfigData::getTrophyData(const char *targetTrophy)
+{
+    if (!this->trophyConfig.HasMember(targetTrophy)) {
+        LastSupper::AssertUtils::fatalAssert("targetTrophy is missng.");
+        return this->trophyConfig;
+    }
+    return this->trophyConfig[targetTrophy];
+}

--- a/Classes/Models/ConfigData/TrophyConfigData.cpp
+++ b/Classes/Models/ConfigData/TrophyConfigData.cpp
@@ -17,6 +17,8 @@ const char* TrophyConfigData::NO_SAVE_CLEAR {"no_save_clear"};
 const char* TrophyConfigData::CHIKEN_SAVE {"chiken_save"};
 const char* TrophyConfigData::TROPHY_COMPLETE {"trophy_complete"};
 const char* TrophyConfigData::TROPHY_ID {"trophyID"};
+const char* TrophyConfigData::COUNT {"count"};
+const char* TrophyConfigData::TIME {"time"};
 
 // コンストラクタ
 bool TrophyConfigData::init()

--- a/Classes/Models/ConfigData/TrophyConfigData.h
+++ b/Classes/Models/ConfigData/TrophyConfigData.h
@@ -1,0 +1,44 @@
+//
+//  TrophyConfigData.hpp
+//  6chefs2
+//
+//  Created by Ryoya Ino on 2017/02/12.
+//
+//
+
+#ifndef TrophyConfigData_h
+#define TrophyConfigData_h
+
+#include "define.h"
+
+class TrophyConfigData : public Ref
+{
+    // Class methods
+public:
+    CREATE_FUNC(TrophyConfigData)
+private:
+    TrophyConfigData(){FUNCLOG};
+    ~TrophyConfigData(){FUNCLOG};
+    
+    // constants
+public:
+    static const char* FAST_CLEAR;
+    static const char* NO_SAVE_CLEAR;
+    static const char* CHIKEN_SAVE;
+    static const char* TROPHY_COMPLETE;
+    static const char* TROPHY_ID;
+    
+    // instance valiables
+private:
+    rapidjson::Document trophyConfig {nullptr};
+    string filePath {};
+    
+    // instance methods
+    public:
+    bool init();
+    int getTrophyId(const char* targetTrophy);
+    int getTrophyIntegerProperty(const char* targetTrophy, const char* targetProperty);
+    rapidjson::Value& getTrophyData(const char* targetTrophy);
+};
+
+#endif /* TrophyConfigData_hpp */

--- a/Classes/Models/ConfigData/TrophyConfigData.h
+++ b/Classes/Models/ConfigData/TrophyConfigData.h
@@ -27,6 +27,8 @@ public:
     static const char* CHIKEN_SAVE;
     static const char* TROPHY_COMPLETE;
     static const char* TROPHY_ID;
+    static const char* TIME;
+    static const char* COUNT;
     
     // instance valiables
 private:

--- a/Classes/Models/PlayerData/GlobalPlayerData.cpp
+++ b/Classes/Models/PlayerData/GlobalPlayerData.cpp
@@ -33,7 +33,7 @@ const char* GlobalPlayerData::ENTER_KEY {"enter_key"};
 const char* GlobalPlayerData::DASH_KEY {"dash_key"};
 
 const int GlobalPlayerData::CHIKEN_SAVE_COUNT {50};
-const int GlobalPlayerData::FAST_CLEAR_TIME {1800};
+const int GlobalPlayerData::FAST_CLEAR_TIME {1980};
 
 
 const int GlobalPlayerData::FAST_CLEAR_TIME_TROPHY_ID {14};

--- a/Classes/Models/PlayerData/GlobalPlayerData.cpp
+++ b/Classes/Models/PlayerData/GlobalPlayerData.cpp
@@ -9,8 +9,8 @@
 #include "Models/PlayerData/GlobalPlayerData.h"
 
 #include "Managers/CsvDataManager.h"
-//#include "Managers/KeyconfigManager.h"
 #include "Managers/NotificationManager.h"
+#include "Managers/ConfigDataManager.h"
 
 #include "Utils/JsonUtils.h"
 #include "Utils/StringUtils.h"
@@ -32,22 +32,15 @@ const char* GlobalPlayerData::CURSOR_KEY {"cursor_key"};
 const char* GlobalPlayerData::ENTER_KEY {"enter_key"};
 const char* GlobalPlayerData::DASH_KEY {"dash_key"};
 
-const int GlobalPlayerData::CHIKEN_SAVE_COUNT {50};
-const int GlobalPlayerData::FAST_CLEAR_TIME {1980};
-
-
-const int GlobalPlayerData::FAST_CLEAR_TIME_TROPHY_ID {14};
-const int GlobalPlayerData::NO_SAVE_CLEAR_TROPHY_ID {15};
-const int GlobalPlayerData::CHIKEN_SAVE_COUNT_TROPHY_ID {16};
-const int GlobalPlayerData::TROPHY_COMPLETE_TROPHY_ID {17};
-
 #pragma mark GlobalDataFile
 
 // 初期化
 bool GlobalPlayerData::init()
 {
+    this->trophyConfigData = ConfigDataManager::getInstance()->getTrophyConfigData();
     if (this->loadGlobalData()) return true;
     if (this->initGlobalData()) return true;
+    
     return false;
 }
 
@@ -118,7 +111,8 @@ bool GlobalPlayerData::isCleared(){return this->getClearCount() > 0 ? true : fal
 void GlobalPlayerData::setBestSaveCount(const int save_count)
 {
     // トロフィーチェック
-    if (save_count == 0) this->setTrophy(GlobalPlayerData::NO_SAVE_CLEAR_TROPHY_ID); // マエストロ
+    ;
+    if (save_count == 0) this->setTrophy(this->trophyConfigData->getTrophyId(TrophyConfigData::NO_SAVE_CLEAR)); // マエストロ
     
     if (save_count > this->getBestSaveCount()) return;
     this->globalData[BEST_SAVE_COUNT].SetInt(save_count);
@@ -137,7 +131,9 @@ void GlobalPlayerData::setBestClearTime(const int play_time)
     this->globalData[BEST_CLEAR_TIME].SetInt(play_time);
     
     // トロフィーチェック
-    if (play_time < FAST_CLEAR_TIME) this->setTrophy(GlobalPlayerData::FAST_CLEAR_TIME_TROPHY_ID); // 3分クッキング
+    int fastClearTime = this->trophyConfigData->getTrophyIntegerProperty(TrophyConfigData::FAST_CLEAR, TrophyConfigData::TIME);
+    int fastClearTrophyId = this->trophyConfigData->getTrophyId(TrophyConfigData::FAST_CLEAR);
+    if (play_time < fastClearTime) this->setTrophy(fastClearTrophyId); // 3分クッキング
 }
 
 // 最短クリア時間を取得
@@ -207,7 +203,7 @@ void GlobalPlayerData::setTrophyComplete()
     int tro_size  = trophies.size();
     if (trophy_count >= tro_size - 1)
     {
-        this->setTrophy(TROPHY_COMPLETE_TROPHY_ID);
+        this->setTrophy(this->trophyConfigData->getTrophyId(TrophyConfigData::TROPHY_COMPLETE));
     }
 }
 

--- a/Classes/Models/PlayerData/GlobalPlayerData.cpp
+++ b/Classes/Models/PlayerData/GlobalPlayerData.cpp
@@ -207,7 +207,7 @@ void GlobalPlayerData::setTrophyComplete()
     int tro_size  = trophies.size();
     if (trophy_count >= tro_size - 1)
     {
-        this->setTrophy(tro_size);
+        this->setTrophy(TROPHY_COMPLETE_TROPHY_ID);
     }
 }
 

--- a/Classes/Models/PlayerData/GlobalPlayerData.h
+++ b/Classes/Models/PlayerData/GlobalPlayerData.h
@@ -11,6 +11,7 @@
 
 #include "define.h"
 #include "Managers/KeyconfigManager.h"
+#include "Models/ConfigData/TrophyConfigData.h"
 
 class GlobalPlayerData : public Ref
 {
@@ -34,16 +35,6 @@ public:
     static const char* ENTER_KEY;
     static const char* DASH_KEY;
     
-    // Record
-    static const int CHIKEN_SAVE_COUNT;
-    static const int FAST_CLEAR_TIME;
-    
-    // trophy_id
-    static const int CHIKEN_SAVE_COUNT_TROPHY_ID;
-    static const int NO_SAVE_CLEAR_TROPHY_ID;
-    static const int FAST_CLEAR_TIME_TROPHY_ID;
-    static const int TROPHY_COMPLETE_TROPHY_ID;
-    
 public:
     CREATE_FUNC(GlobalPlayerData)
 private:
@@ -52,6 +43,7 @@ private:
 // Instance valiables
 private:
     rapidjson::Document globalData {nullptr};
+    TrophyConfigData* trophyConfigData {nullptr};
 
 // Instance methods
 private:

--- a/Classes/Models/PlayerData/LocalPlayerData.cpp
+++ b/Classes/Models/PlayerData/LocalPlayerData.cpp
@@ -7,6 +7,8 @@
 //
 
 #include "Models/PlayerData/LocalPlayerData.h"
+
+#include "Managers/ConfigDataManager.h"
 #include "Models/PlayerData/GlobalPlayerData.h"
 #include "Utils/AssertUtils.h"
 #include "Utils/JsonUtils.h"
@@ -111,7 +113,10 @@ void LocalPlayerData::incrementSaveCount()
     };
     
     // トロフィーチェック
-    if (save_count >= GlobalPlayerData::CHIKEN_SAVE_COUNT) this->setTrophy(GlobalPlayerData::CHIKEN_SAVE_COUNT_TROPHY_ID);
+    TrophyConfigData* trophyConfigData { ConfigDataManager::getInstance()->getTrophyConfigData() };
+    int chikenSaveCount = trophyConfigData->getTrophyIntegerProperty(TrophyConfigData::CHIKEN_SAVE, TrophyConfigData::COUNT);
+    int chikenSaveTrophyId = trophyConfigData->getTrophyId(TrophyConfigData::CHIKEN_SAVE);
+    if (save_count >= chikenSaveCount) this->setTrophy(chikenSaveTrophyId);
 }
 
 // セーブ回数を取得

--- a/Classes/resources.h
+++ b/Classes/resources.h
@@ -20,6 +20,7 @@ namespace Resource
         static const std::string MASTER_CONFIG = BASE_PATH + "MasterConfig.json";
         static const std::string EVENT_SCRIPT_VALIDATOR = BASE_PATH + "EventScriptValidator.json";
         static const std::string BATTLE_CHARACTER = BASE_PATH + "BattleCharacter.json";
+        static const std::string TROPHY_CONFIG = BASE_PATH + "TrophyConfig.json";
     };
     
     namespace CsvFiles

--- a/Resources/config/TrophyConfig.json
+++ b/Resources/config/TrophyConfig.json
@@ -1,0 +1,16 @@
+{
+    "fast_clear": {
+        "trophyID": 14,
+        "time": 1980
+    },
+    "no_save_clear": {
+        "trophyID": 15
+    },
+    "chiken_save": {
+        "trophyID": 16,
+        "count": 50
+    },
+    "trophy_complete": {
+        "trophyID": 17
+    }
+}

--- a/proj.ios_mac/6chefs2.xcodeproj/project.pbxproj
+++ b/proj.ios_mac/6chefs2.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		268E3FAA1D64BFD90098B235 /* ConfigDataManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 268E3FA71D64BFD90098B235 /* ConfigDataManager.cpp */; };
 		269211561CE89FB5005C0E5A /* config in Resources */ = {isa = PBXBuildFile; fileRef = 269211551CE89FB5005C0E5A /* config */; };
 		269211571CE8A9A9005C0E5A /* config in Resources */ = {isa = PBXBuildFile; fileRef = 269211551CE89FB5005C0E5A /* config */; };
+		26B6DA4C1E50A9FE008BC70A /* TrophyConfigData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26B6DA4A1E50A9FE008BC70A /* TrophyConfigData.cpp */; };
+		26B6DA4D1E50A9FE008BC70A /* TrophyConfigData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26B6DA4A1E50A9FE008BC70A /* TrophyConfigData.cpp */; };
 		26E301571DF2D6B7000E585D /* CountDownDisplay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E301551DF2D6B7000E585D /* CountDownDisplay.cpp */; };
 		26E301581DF2D6B7000E585D /* CountDownDisplay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E301551DF2D6B7000E585D /* CountDownDisplay.cpp */; };
 		26E950B81CDA50C30018BF93 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 26E950B61CDA50C30018BF93 /* InfoPlist.strings */; };
@@ -471,6 +473,8 @@
 		268E3FA71D64BFD90098B235 /* ConfigDataManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConfigDataManager.cpp; sourceTree = "<group>"; };
 		268E3FA81D64BFD90098B235 /* ConfigDataManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConfigDataManager.h; sourceTree = "<group>"; };
 		269211551CE89FB5005C0E5A /* config */ = {isa = PBXFileReference; lastKnownFileType = folder; path = config; sourceTree = "<group>"; };
+		26B6DA4A1E50A9FE008BC70A /* TrophyConfigData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TrophyConfigData.cpp; path = ConfigData/TrophyConfigData.cpp; sourceTree = "<group>"; };
+		26B6DA4B1E50A9FE008BC70A /* TrophyConfigData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TrophyConfigData.h; path = ConfigData/TrophyConfigData.h; sourceTree = "<group>"; };
 		26E301551DF2D6B7000E585D /* CountDownDisplay.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CountDownDisplay.cpp; sourceTree = "<group>"; };
 		26E301561DF2D6B7000E585D /* CountDownDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountDownDisplay.h; sourceTree = "<group>"; };
 		26E950B91CDA51200018BF93 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "6chefs2-desktop/Images.xcassets"; sourceTree = SOURCE_ROOT; };
@@ -943,6 +947,8 @@
 				26460BA31D72EF1500F0336C /* DebugConfigData.h */,
 				2672D5021D72F79700AC0E96 /* MasterConfigData.cpp */,
 				2672D5031D72F79700AC0E96 /* MasterConfigData.h */,
+				26B6DA4A1E50A9FE008BC70A /* TrophyConfigData.cpp */,
+				26B6DA4B1E50A9FE008BC70A /* TrophyConfigData.h */,
 			);
 			name = ConfigData;
 			sourceTree = "<group>";
@@ -2018,6 +2024,7 @@
 				DC668C2B1D966C8900ED569C /* MapObjectCommandQueue.cpp in Sources */,
 				DC03923B1C871E1000C50E8E /* GameTask.cpp in Sources */,
 				DC0391951C871E1000C50E8E /* EventFactory.cpp in Sources */,
+				26B6DA4C1E50A9FE008BC70A /* TrophyConfigData.cpp in Sources */,
 				DCB075441C9417B900D69F72 /* KeyconfigManager.cpp in Sources */,
 				DCA4495D1DA0EAA0005C5F9A /* DungeonSceneEventHandler.cpp in Sources */,
 			);
@@ -2182,6 +2189,7 @@
 				DC0391BC1C871E1000C50E8E /* DungeonMainMenuLayer.cpp in Sources */,
 				DC0391E01C871E1000C50E8E /* SoundManager.cpp in Sources */,
 				DC0392481C871E1000C50E8E /* NotificationBand.cpp in Sources */,
+				26B6DA4D1E50A9FE008BC70A /* TrophyConfigData.cpp in Sources */,
 				DC0391BA1C871E1000C50E8E /* DocumentMenuLayer.cpp in Sources */,
 				DC0391CC1C871E1000C50E8E /* CharacterMessageLayer.cpp in Sources */,
 				DC01829E1D7A9D8900E556D1 /* Normal.cpp in Sources */,


### PR DESCRIPTION
 - 33分クッキング対応のためクリアタイム基準値を1980秒に修正
 -  `congi/TrophyConfig.json` で1,2との差分を外から設定できるようにした