### PR TITLE
[WIP]OpeningSceneの実装

### DIFF
--- a/Classes/Datas/Scene/OpeningSceneData.cpp
+++ b/Classes/Datas/Scene/OpeningSceneData.cpp
@@ -1,0 +1,16 @@
+//
+//  OpeningSceneData.cpp
+//  6chefs2
+//
+//  Created by Ryoya Ino on 2017/02/13.
+//
+//
+
+#include "Datas/Scene/OpeningSceneData.h"
+
+bool OpeningSceneData::init()
+{
+    this->textureFilePaths = {};
+    this->soundFilePaths = {};
+    return true;
+}

--- a/Classes/Datas/Scene/OpeningSceneData.h
+++ b/Classes/Datas/Scene/OpeningSceneData.h
@@ -1,0 +1,27 @@
+//
+//  OpeningSceneData.hpp
+//  6chefs2
+//
+//  Created by Ryoya Ino on 2017/02/13.
+//
+//
+
+#ifndef OpeningSceneData_h
+#define OpeningSceneData_h
+
+#include "Datas/Scene/SceneData.h"
+
+class OpeningSceneData : public SceneData
+{
+    // クラスメソッド
+public:
+    CREATE_FUNC(OpeningSceneData)
+    
+    // インスタンスメソッド
+private:
+    OpeningSceneData() {FUNCLOG};
+    ~OpeningSceneData() {FUNCLOG};
+    bool init();
+};
+
+#endif /* OpeningSceneData_hpp */

--- a/Classes/Models/ConfigData/MasterConfigData.cpp
+++ b/Classes/Models/ConfigData/MasterConfigData.cpp
@@ -18,6 +18,7 @@ const char* MasterConfigData::DISPLAY {"display"};
 const char* MasterConfigData::TWO_ICON {"two_icon"};
 const char* MasterConfigData::FRIENDSHIP {"friendship"};
 const char* MasterConfigData::SPECIAL_ROOM {"special_room"};
+const char* MasterConfigData::OPENING_SCENE {"opening_scene"};
 const char* MasterConfigData::OPENING_VIDEO_FILE {"opening_video_file"};
 const char* MasterConfigData::OPENING_BGM_FILE {"opening_bgm_file"};
 

--- a/Classes/Models/ConfigData/MasterConfigData.cpp
+++ b/Classes/Models/ConfigData/MasterConfigData.cpp
@@ -18,6 +18,8 @@ const char* MasterConfigData::DISPLAY {"display"};
 const char* MasterConfigData::TWO_ICON {"two_icon"};
 const char* MasterConfigData::FRIENDSHIP {"friendship"};
 const char* MasterConfigData::SPECIAL_ROOM {"special_room"};
+const char* MasterConfigData::OPENING_VIDEO_FILE {"opening_video_file"};
+const char* MasterConfigData::OPENING_BGM_FILE {"opening_bgm_file"};
 
 // コンストラクタ
 bool MasterConfigData::init()

--- a/Classes/Models/ConfigData/MasterConfigData.h
+++ b/Classes/Models/ConfigData/MasterConfigData.h
@@ -28,6 +28,7 @@ public:
     static const char* TWO_ICON;
     static const char* FRIENDSHIP;
     static const char* SPECIAL_ROOM;
+    static const char* OPENING_SCENE;
     static const char* OPENING_VIDEO_FILE;
     static const char* OPENING_BGM_FILE;
     

--- a/Classes/Models/ConfigData/MasterConfigData.h
+++ b/Classes/Models/ConfigData/MasterConfigData.h
@@ -28,6 +28,8 @@ public:
     static const char* TWO_ICON;
     static const char* FRIENDSHIP;
     static const char* SPECIAL_ROOM;
+    static const char* OPENING_VIDEO_FILE;
+    static const char* OPENING_BGM_FILE;
     
     // instance valiables
 private:

--- a/Classes/Scenes/OpeningScene.cpp
+++ b/Classes/Scenes/OpeningScene.cpp
@@ -1,0 +1,105 @@
+//
+//  OpeningScene.cpp
+//  6chefs2
+//
+//  Created by Ryoya Ino on 2017/02/13.
+//
+//
+
+#include "Scenes/OpeningScene.h"
+
+#include "Scenes/TitleScene.h"
+#include "Datas/Scene/OpeningSceneData.h"
+#include "Layers/EventListener/ConfigEventListenerLayer.h"
+#include "Layers/EventListener/EventListenerKeyboardLayer.h"
+#include "Layers/LoadingLayer.h"
+// #include "Layers/Dungeon/VideoLayer.h"
+
+// 初期化
+bool OpeningScene::init()
+{
+    if (!BaseScene::init(OpeningSceneData::create())) return false;
+    
+    MasterConfigData* masterConfigData { ConfigDataManager::getInstance()->getMasterConfigData() };
+    _videoFileName = masterConfigData->getString(MasterConfigData::OPENING_VIDEO_FILE);
+    _bgmFileName = masterConfigData->getString(MasterConfigData::OPENING_BGM_FILE);
+    
+    return true;
+}
+
+// シーン生成直後
+void OpeningScene::onEnter()
+{
+    BaseScene::onEnter();
+}
+
+// データ読み込み後
+void OpeningScene::onPreloadFinished(LoadingLayer *loadingLayer)
+{
+    // ローディング終了
+    loadingLayer->onLoadFinished();
+    
+    //this->setVideoLayer();
+    this->setVideoLayerDummy();
+    //this->setVideoBgm();
+    this->setVideoBgmDummy();
+    this->setPressEnter();
+}
+
+// 動画レイヤーをセット
+void OpeningScene::setVideoLayer()
+{
+    // VideoLayer* videoLayer { VideoLayer::create(_videoFileName, true, [this]{
+    //         SoundManager::getInstance()->stopBgmAll();
+    //         Director::getInstance()->replaceScene(TitleScene::create());
+    //     }) };
+    // videoLayer->setPosition(WINDOW_CENTER);
+    // this->addChild(videoLayer);
+}
+
+// 動画レイヤーのダミー
+void OpeningScene::setVideoLayerDummy()
+{
+    // ダミー動画レイヤー
+    Label* videoLayer {Label::createWithTTF("動画再生なう\nBGMはループしないようにしたよ", Resource::Font::MESSAGE, 40)};
+    videoLayer->setPosition(WINDOW_CENTER);
+    this->addChild(videoLayer);
+    
+    // キーボードリスナ生成(Videoのコールバックにするからあとで消す)
+    EventListenerKeyboardLayer* listener {EventListenerKeyboardLayer::create()};
+    listener->onEnterKeyPressed = []{
+        SoundManager::getInstance()->stopBGMAll();
+        Director::getInstance()->replaceScene(TitleScene::create());
+    };
+    this->addChild(listener);
+}
+
+// BGMのセット
+void OpeningScene::setVideoBgm()
+{
+    SoundManager::getInstance()->playBGM(_bgmFileName, false);
+}
+
+// BGMのダミーセット
+void OpeningScene::setVideoBgmDummy()
+{
+    SoundManager::getInstance()->playBGM("idol.mp3", false, 1.0);
+}
+
+// PRESS ENTERをセット
+void OpeningScene::setPressEnter()
+{
+    // PRESS ENTER
+    Label* pressEnter {Label::createWithTTF("PRESS ENTER", Resource::Font::MESSAGE, 16)};
+    pressEnter->setPosition(Point(WINDOW_WIDTH/2, pressEnter->getContentSize().height * 2));
+    pressEnter->setOpacity(0);
+    pressEnter->setLocalZOrder(999);
+    this->addChild(pressEnter);
+    
+    // 点滅を設定
+    ActionInterval* flashing = Sequence::createWithTwoActions(
+        TargetedAction::create(pressEnter, FadeTo::create(0.6f, 200)),
+        TargetedAction::create(pressEnter, FadeTo::create(0.6f, 30))
+    );
+    this->runAction(RepeatForever::create(flashing));
+}

--- a/Classes/Scenes/OpeningScene.cpp
+++ b/Classes/Scenes/OpeningScene.cpp
@@ -41,8 +41,7 @@ void OpeningScene::onPreloadFinished(LoadingLayer *loadingLayer)
     
     //this->setVideoLayer();
     this->setVideoLayerDummy();
-    //this->setVideoBgm();
-    this->setVideoBgmDummy();
+    this->setVideoBgm();
     this->setPressEnter();
 }
 
@@ -77,13 +76,7 @@ void OpeningScene::setVideoLayerDummy()
 // BGMのセット
 void OpeningScene::setVideoBgm()
 {
-    SoundManager::getInstance()->playBGM(_bgmFileName, false);
-}
-
-// BGMのダミーセット
-void OpeningScene::setVideoBgmDummy()
-{
-    SoundManager::getInstance()->playBGM("idol.mp3", false, 1.0);
+    SoundManager::getInstance()->playBGM(_bgmFileName, false, 2.5);
 }
 
 // PRESS ENTERをセット

--- a/Classes/Scenes/OpeningScene.cpp
+++ b/Classes/Scenes/OpeningScene.cpp
@@ -13,7 +13,7 @@
 #include "Layers/EventListener/ConfigEventListenerLayer.h"
 #include "Layers/EventListener/EventListenerKeyboardLayer.h"
 #include "Layers/LoadingLayer.h"
-// #include "Layers/Dungeon/VideoLayer.h"
+#include "UI/Video/VideoPlayer.h"
 
 // 初期化
 bool OpeningScene::init()
@@ -39,8 +39,8 @@ void OpeningScene::onPreloadFinished(LoadingLayer *loadingLayer)
     // ローディング終了
     loadingLayer->onLoadFinished();
     
-    //this->setVideoLayer();
-    this->setVideoLayerDummy();
+    this->setVideoLayer();
+    //this->setVideoLayerDummy();
     this->setVideoBgm();
     this->setPressEnter();
 }
@@ -48,19 +48,18 @@ void OpeningScene::onPreloadFinished(LoadingLayer *loadingLayer)
 // 動画レイヤーをセット
 void OpeningScene::setVideoLayer()
 {
-    // VideoLayer* videoLayer { VideoLayer::create(_videoFileName, true, [this]{
-    //         SoundManager::getInstance()->stopBgmAll();
-    //         Director::getInstance()->replaceScene(TitleScene::create());
-    //     }) };
-    // videoLayer->setPosition(WINDOW_CENTER);
-    // this->addChild(videoLayer);
+     VideoPlayer* videoPlayer { VideoPlayer::create(_videoFileName, true, [this]{
+            SoundManager::getInstance()->stopBGMAll();
+            Director::getInstance()->replaceScene(TitleScene::create());
+         }) };
+     this->addChild(videoPlayer);
 }
 
-// 動画レイヤーのダミー
+// 動画レイヤーのダミー(テスト用に残しておく)
 void OpeningScene::setVideoLayerDummy()
 {
     // ダミー動画レイヤー
-    Label* videoLayer {Label::createWithTTF("動画再生なう\nBGMはループしないようにしたよ", Resource::Font::MESSAGE, 40)};
+    Label* videoLayer {Label::createWithTTF("動画再生なう", Resource::Font::MESSAGE, 40)};
     videoLayer->setPosition(WINDOW_CENTER);
     this->addChild(videoLayer);
     

--- a/Classes/Scenes/OpeningScene.h
+++ b/Classes/Scenes/OpeningScene.h
@@ -31,7 +31,6 @@ private:
     void setVideoLayer();
     void setVideoLayerDummy();
     void setVideoBgm();
-    void setVideoBgmDummy();
     
 public:
     OpeningScene() {FUNCLOG};

--- a/Classes/Scenes/OpeningScene.h
+++ b/Classes/Scenes/OpeningScene.h
@@ -1,0 +1,41 @@
+//
+//  OpeningScene.hpp
+//  6chefs2
+//
+//  Created by Ryoya Ino on 2017/02/13.
+//
+//
+
+#ifndef OpeningScene_hpp
+#define OpeningScene_hpp
+
+#include "Scenes/BaseScene.h"
+
+class OpeningScene : public BaseScene
+{
+    // クラスメソッド
+public:
+    CREATE_FUNC(OpeningScene);
+
+    // インスタンス変数
+private:
+    string _videoFileName;
+    string _bgmFileName;
+    
+    // インスタンスメソッド
+private:
+    virtual bool init();
+    virtual void onEnter();
+    void onPreloadFinished(LoadingLayer* loadingLayer);
+    void setPressEnter();
+    void setVideoLayer();
+    void setVideoLayerDummy();
+    void setVideoBgm();
+    void setVideoBgmDummy();
+    
+public:
+    OpeningScene() {FUNCLOG};
+    ~OpeningScene() {FUNCLOG};
+};
+
+#endif /* OpeningScene_hpp */

--- a/Classes/Scenes/StartUpScene.cpp
+++ b/Classes/Scenes/StartUpScene.cpp
@@ -11,9 +11,6 @@
 #include "Datas/Scene/StartUpSceneData.h"
 #include "Layers/EventListener/ConfigEventListenerLayer.h"
 #include "Layers/LoadingLayer.h"
-#include "Utils/JsonUtils.h"
-#include "Utils/CsvUtils.h"
-#include "Utils/AssertUtils.h"
 
 // 初期化
 bool StartUpScene::init()

--- a/Classes/Scenes/StartUpScene.cpp
+++ b/Classes/Scenes/StartUpScene.cpp
@@ -8,6 +8,7 @@
 
 #include "Scenes/StartUpScene.h"
 #include "Scenes/TitleScene.h"
+#include "Scenes/OpeningScene.h"
 #include "Datas/Scene/StartUpSceneData.h"
 #include "Layers/EventListener/ConfigEventListenerLayer.h"
 #include "Layers/LoadingLayer.h"
@@ -68,7 +69,11 @@ void StartUpScene::onPreloadFinished(LoadingLayer *loadingLayer)
             DelayTime::create(1.5f),
             TargetedAction::create(logo,FadeOut::create(1.0f)),
             CallFunc::create([](){
-                Director::getInstance()->replaceScene(TitleScene::create());
+                if (ConfigDataManager::getInstance()->getMasterConfigData()->isDisplay(MasterConfigData::OPENING_SCENE)) {
+                    Director::getInstance()->replaceScene(OpeningScene::create());
+                } else {
+                    Director::getInstance()->replaceScene(TitleScene::create());
+                }
             }),
             nullptr
         )

--- a/Resources/config/MasterConfig.json
+++ b/Resources/config/MasterConfig.json
@@ -5,5 +5,7 @@
         "two_icon": true,
         "friendship": false,
         "special_room": true
-    }
+    },
+    "opening_video_file": "OPmovie.mp4",
+    "opening_bgm_file": "OPBGM.mp3"
 }

--- a/Resources/config/MasterConfig.json
+++ b/Resources/config/MasterConfig.json
@@ -4,7 +4,8 @@
     "display": {
         "two_icon": true,
         "friendship": false,
-        "special_room": true
+        "special_room": true,
+        "opening_scene": true
     },
     "opening_video_file": "OPmovie.mp4",
     "opening_bgm_file": "OPBGM.mp3"

--- a/proj.ios_mac/6chefs2.xcodeproj/project.pbxproj
+++ b/proj.ios_mac/6chefs2.xcodeproj/project.pbxproj
@@ -45,6 +45,10 @@
 		26B6DA4D1E50A9FE008BC70A /* TrophyConfigData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26B6DA4A1E50A9FE008BC70A /* TrophyConfigData.cpp */; };
 		26E22CF91E51F26D0018A55C /* EquipItemEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E22CF71E51F26D0018A55C /* EquipItemEvent.cpp */; };
 		26E22CFA1E51F26D0018A55C /* EquipItemEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E22CF71E51F26D0018A55C /* EquipItemEvent.cpp */; };
+		26E22CF11E50B8A40018A55C /* OpeningScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E22CEF1E50B8A40018A55C /* OpeningScene.cpp */; };
+		26E22CF21E50B8A40018A55C /* OpeningScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E22CEF1E50B8A40018A55C /* OpeningScene.cpp */; };
+		26E22CF51E50B9E50018A55C /* OpeningSceneData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E22CF31E50B9E50018A55C /* OpeningSceneData.cpp */; };
+		26E22CF61E50B9E50018A55C /* OpeningSceneData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E22CF31E50B9E50018A55C /* OpeningSceneData.cpp */; };
 		26E301571DF2D6B7000E585D /* CountDownDisplay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E301551DF2D6B7000E585D /* CountDownDisplay.cpp */; };
 		26E301581DF2D6B7000E585D /* CountDownDisplay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E301551DF2D6B7000E585D /* CountDownDisplay.cpp */; };
 		26E950B81CDA50C30018BF93 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 26E950B61CDA50C30018BF93 /* InfoPlist.strings */; };
@@ -498,6 +502,10 @@
 		26B6DA4B1E50A9FE008BC70A /* TrophyConfigData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TrophyConfigData.h; path = ConfigData/TrophyConfigData.h; sourceTree = "<group>"; };
 		26E22CF71E51F26D0018A55C /* EquipItemEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EquipItemEvent.cpp; sourceTree = "<group>"; };
 		26E22CF81E51F26D0018A55C /* EquipItemEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EquipItemEvent.h; sourceTree = "<group>"; };
+		26E22CEF1E50B8A40018A55C /* OpeningScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OpeningScene.cpp; sourceTree = "<group>"; };
+		26E22CF01E50B8A40018A55C /* OpeningScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpeningScene.h; sourceTree = "<group>"; };
+		26E22CF31E50B9E50018A55C /* OpeningSceneData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OpeningSceneData.cpp; sourceTree = "<group>"; };
+		26E22CF41E50B9E50018A55C /* OpeningSceneData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpeningSceneData.h; sourceTree = "<group>"; };
 		26E301551DF2D6B7000E585D /* CountDownDisplay.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CountDownDisplay.cpp; sourceTree = "<group>"; };
 		26E301561DF2D6B7000E585D /* CountDownDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountDownDisplay.h; sourceTree = "<group>"; };
 		26E950B91CDA51200018BF93 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "6chefs2-desktop/Images.xcassets"; sourceTree = SOURCE_ROOT; };
@@ -1272,6 +1280,8 @@
 				DC03906D1C871E1000C50E8E /* StartUpSceneData.h */,
 				DC03906E1C871E1000C50E8E /* TitleSceneData.cpp */,
 				DC03906F1C871E1000C50E8E /* TitleSceneData.h */,
+				26E22CF31E50B9E50018A55C /* OpeningSceneData.cpp */,
+				26E22CF41E50B9E50018A55C /* OpeningSceneData.h */,
 			);
 			path = Scene;
 			sourceTree = "<group>";
@@ -1575,6 +1585,8 @@
 				DC03913F1C871E1000C50E8E /* TitleScene.h */,
 				9FB79E6F1D363073004E81CF /* AssertScene.cpp */,
 				9FB79E701D363073004E81CF /* AssertScene.h */,
+				26E22CEF1E50B8A40018A55C /* OpeningScene.cpp */,
+				26E22CF01E50B8A40018A55C /* OpeningScene.h */,
 			);
 			path = Scenes;
 			sourceTree = "<group>";
@@ -1931,6 +1943,7 @@
 			files = (
 				DC7F6E201DA0B20D007AE8B5 /* HitPoint.cpp in Sources */,
 				DC0391BF1C871E1000C50E8E /* MenuLayer.cpp in Sources */,
+				26E22CF11E50B8A40018A55C /* OpeningScene.cpp in Sources */,
 				26FBED381C98514A002FAFF7 /* CsvUtils.cpp in Sources */,
 				DCA449631DA21698005C5F9A /* Sight.cpp in Sources */,
 				DC0391EF1C871E1000C50E8E /* MapObjectFactory.cpp in Sources */,
@@ -2094,6 +2107,7 @@
 				DC03923F1C871E1000C50E8E /* Cloud.cpp in Sources */,
 				2626AEC61D99895E00D5623B /* AssertHelper.cpp in Sources */,
 				DC0391DB1C871E1000C50E8E /* NotificationManager.cpp in Sources */,
+				26E22CF51E50B9E50018A55C /* OpeningSceneData.cpp in Sources */,
 				DC8C4D351D8FD57C00FF0A1E /* AttackDetector.cpp in Sources */,
 				DC03920B1C871E1000C50E8E /* WaterArea.cpp in Sources */,
 				DC0391B11C871E1000C50E8E /* SelectEventLayer.cpp in Sources */,
@@ -2158,6 +2172,7 @@
 				DC03918C1C871E1000C50E8E /* Fog.cpp in Sources */,
 				DCA449641DA21698005C5F9A /* Sight.cpp in Sources */,
 				9FB79E6E1D362EBE004E81CF /* AssertUtils.cpp in Sources */,
+				26E22CF21E50B8A40018A55C /* OpeningScene.cpp in Sources */,
 				DC0391EE1C871E1000C50E8E /* MapObject.cpp in Sources */,
 				DC0391FE1C871E1000C50E8E /* RandomMove.cpp in Sources */,
 				DC0391EA1C871E1000C50E8E /* GhostObject.cpp in Sources */,
@@ -2235,6 +2250,7 @@
 				DC0391741C871E1000C50E8E /* CharacterMessageData.cpp in Sources */,
 				DC23C86D1D8BD9A7008E57F3 /* PathFinder.cpp in Sources */,
 				DCA4495E1DA0EAA0005C5F9A /* DungeonSceneEventHandler.cpp in Sources */,
+				26E22CF61E50B9E50018A55C /* OpeningSceneData.cpp in Sources */,
 				DC03919E1C871E1000C50E8E /* GameEvent.cpp in Sources */,
 				DC0391CE1C871E1000C50E8E /* MessageLayer.cpp in Sources */,
 				DC0391D01C871E1000C50E8E /* StoryMessageLayer.cpp in Sources */,


### PR DESCRIPTION
issue #242 
Releted PullRquest #248 

設定は `config/MasterConfig.json` に記述
```json
{
    "version": "Ver.1.1",
    "copyright": "Copyright (C) 2014-2017 最後の晩餐 All Rights Reserved.",
    "display": {
        "two_icon": true,
        "friendship": false,
        "special_room": true,
        "opening_scene": true
    },
    "opening_video_file": "OPmovie.mp4",
    "opening_bgm_file": "OPBGM.mp3"
}
```
- opening_scene
  - true: startup->opening->titile
  - false: startup->titile (今まで通り)

- opening_video_file
`Resouces/video` ディレクトリから該当動画を探す

- opening_bgm_file
`Resouces/bgm` ディレクトリから該当BGMを探す（ループ再生はしない）