### PR TITLE
CommonEventがチャプター移動時に取れなくなるバグの修正

### DIFF
--- a/Classes/Models/CommonEventScripts.cpp
+++ b/Classes/Models/CommonEventScripts.cpp
@@ -61,10 +61,6 @@ bool CommonEventScripts::loadEventScripts(const int chapter)
 // イベントスクリプトの解放
 void CommonEventScripts::releaseEventScripts()
 {
-    for (auto itr = this->eventScripts.begin(); itr != this->eventScripts.end(); ++itr)
-    {
-        CC_SAFE_RELEASE_NULL(itr->second);
-    }
     this->eventScripts.clear();
 }
 


### PR DESCRIPTION
チャプター移動時に引き続き読みこむCommonEventがある場合、
一旦クリアするのでそのイベントをメモリ解放してしまっていた
自動で解放されるようなので、解放処理はなくした